### PR TITLE
Add gathering metrics in a time range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Single metric gather.
+- Metric range gather.
 - Allow multiple datasources in the same dashboard.
 - Debug flag that will set a verbose logger (will break UI rendering but prints errors and infos).
 - Termdash render engine implementation for widgets.

--- a/internal/mocks/service/metric/Gatherer.go
+++ b/internal/mocks/service/metric/Gatherer.go
@@ -13,6 +13,29 @@ type Gatherer struct {
 	mock.Mock
 }
 
+// GatherRange provides a mock function with given fields: ctx, query, start, end, step
+func (_m *Gatherer) GatherRange(ctx context.Context, query model.Query, start time.Time, end time.Time, step time.Duration) ([]model.MetricSeries, error) {
+	ret := _m.Called(ctx, query, start, end, step)
+
+	var r0 []model.MetricSeries
+	if rf, ok := ret.Get(0).(func(context.Context, model.Query, time.Time, time.Time, time.Duration) []model.MetricSeries); ok {
+		r0 = rf(ctx, query, start, end, step)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]model.MetricSeries)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, model.Query, time.Time, time.Time, time.Duration) error); ok {
+		r1 = rf(ctx, query, start, end, step)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GatherSingle provides a mock function with given fields: ctx, query, t
 func (_m *Gatherer) GatherSingle(ctx context.Context, query model.Query, t time.Time) ([]model.MetricSeries, error) {
 	ret := _m.Called(ctx, query, t)

--- a/internal/model/metric.go
+++ b/internal/model/metric.go
@@ -4,7 +4,7 @@ import (
 	"time"
 )
 
-// Metric represents a measured metrics in time.
+// Metric represents a measured value in time.
 type Metric struct {
 	Value float64
 	TS    time.Time

--- a/internal/service/metric/datasource/datasource.go
+++ b/internal/service/metric/datasource/datasource.go
@@ -90,6 +90,14 @@ func (g *gatherer) GatherSingle(ctx context.Context, query model.Query, t time.T
 	return dsg.GatherSingle(ctx, query, t)
 }
 
+func (g *gatherer) GatherRange(ctx context.Context, query model.Query, start, end time.Time, step time.Duration) ([]model.MetricSeries, error) {
+	dsg, ok := g.gatherers[query.DatasourceID]
+	if !ok {
+		return nil, fmt.Errorf("datasource %s does not exists", query.DatasourceID)
+	}
+	return dsg.GatherRange(ctx, query, start, end, step)
+}
+
 func createGatherer(cfg ConfigGatherer, ds model.Datasource) (metric.Gatherer, error) {
 	switch {
 	case ds.Prometheus != nil:

--- a/internal/service/metric/fake/fake.go
+++ b/internal/service/metric/fake/fake.go
@@ -2,6 +2,7 @@ package fake
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/slok/meterm/internal/model"
@@ -28,4 +29,54 @@ func (g Gatherer) GatherSingle(_ context.Context, _ model.Query, t time.Time) ([
 			},
 		},
 	}, nil
+}
+
+// GatherRange satisfies metric.Gatherer interface.
+func (g Gatherer) GatherRange(ctx context.Context, query model.Query, start, end time.Time, step time.Duration) ([]model.MetricSeries, error) {
+	// Get some series.
+	series := []model.MetricSeries{}
+	seriesQ := 3
+	for i := 0; i < seriesQ; i++ {
+		id := fmt.Sprintf("fake-%d", i)
+		s := model.MetricSeries{
+			ID: id,
+			Labels: map[string]string{
+				"fake": "true",
+				"name": id,
+			},
+			Metrics: generateMetrics(i*11, start, end, step),
+		}
+
+		series = append(series, s)
+	}
+
+	return series, nil
+}
+
+func generateMetrics(offset int, start, end time.Time, step time.Duration) []model.Metric {
+	metrics := []model.Metric{}
+	for i := 1; ; i++ {
+		t := start.Add(step * time.Duration(i))
+		val := float64(offset + t.Second())
+
+		// Add some noise.
+		noise := t.Second() % 3
+		if noise%2 == 0 {
+			val = val + float64(noise)
+		} else {
+			val = val - float64(noise)
+		}
+
+		m := model.Metric{
+			TS:    t,
+			Value: val + float64(offset),
+		}
+		metrics = append(metrics, m)
+
+		if t.After(end) {
+			break
+		}
+	}
+
+	return metrics
 }

--- a/internal/service/metric/gather.go
+++ b/internal/service/metric/gather.go
@@ -11,4 +11,8 @@ import (
 type Gatherer interface {
 	// GatherSingle gathers one single metric at a point in time.
 	GatherSingle(ctx context.Context, query model.Query, t time.Time) ([]model.MetricSeries, error)
+	// GatherRange gathers multiple metrics based on a start and an end using a step duration
+	// to know how many metrics needs to gather.
+	// The returned metrics on the series should be ordered.
+	GatherRange(ctx context.Context, query model.Query, start, end time.Time, step time.Duration) ([]model.MetricSeries, error)
 }

--- a/internal/service/metric/prometheus/prometheus_test.go
+++ b/internal/service/metric/prometheus/prometheus_test.go
@@ -48,7 +48,7 @@ func TestGathererGatherSingle(t *testing.T) {
 				&prommodel.Sample{
 					Metric: prommodel.Metric{
 						"k1":       "v1",
-						"k2":       "k2",
+						"k2":       "v2",
 						"__name__": "test-metric",
 					},
 					Value:     prommodel.SampleValue(1.2),
@@ -57,10 +57,10 @@ func TestGathererGatherSingle(t *testing.T) {
 			},
 			expMetricSeries: []model.MetricSeries{
 				model.MetricSeries{
-					ID: "test-metric",
+					ID: `test-metric{k1="v1", k2="v2"}`,
 					Labels: map[string]string{
 						"k1":       "v1",
-						"k2":       "k2",
+						"k2":       "v2",
 						"__name__": "test-metric",
 					},
 					Metrics: []model.Metric{
@@ -68,143 +68,6 @@ func TestGathererGatherSingle(t *testing.T) {
 							Value: 1.2,
 							TS:    now,
 						},
-					},
-				},
-			},
-		},
-		{
-			name: "When Prometheus returns a Vector with multiple metrics the Gatherer should return the translated metric.",
-			prommetric: prommodel.Vector{
-				&prommodel.Sample{
-					Metric:    prommodel.Metric{"k1": "v1", "k2": "k2", "__name__": "test-metric"},
-					Value:     prommodel.SampleValue(1.2),
-					Timestamp: prommodel.TimeFromUnixNano(now.UnixNano()),
-				},
-				&prommodel.Sample{
-					Metric:    prommodel.Metric{"k1": "v1", "k2": "k2", "__name__": "test-metric"},
-					Value:     prommodel.SampleValue(3.4),
-					Timestamp: prommodel.TimeFromUnixNano(now.UnixNano()),
-				},
-				&prommodel.Sample{
-					Metric:    prommodel.Metric{"k1": "v1", "k2": "k2", "__name__": "test-metric"},
-					Value:     prommodel.SampleValue(5.5),
-					Timestamp: prommodel.TimeFromUnixNano(now.UnixNano()),
-				},
-				&prommodel.Sample{
-					Metric:    prommodel.Metric{"k1": "v1", "k2": "k2", "k3": "k3", "__name__": "test-metric"},
-					Value:     prommodel.SampleValue(6.7),
-					Timestamp: prommodel.TimeFromUnixNano(now.UnixNano()),
-				},
-				&prommodel.Sample{
-					Metric:    prommodel.Metric{"k5": "v5", "__name__": "test-metric"},
-					Value:     prommodel.SampleValue(8.9),
-					Timestamp: prommodel.TimeFromUnixNano(now.UnixNano()),
-				},
-				&prommodel.Sample{
-					Metric:    prommodel.Metric{"k1": "v1", "k2": "k2", "__name__": "test-metric2"},
-					Value:     prommodel.SampleValue(10.11),
-					Timestamp: prommodel.TimeFromUnixNano(now.UnixNano()),
-				},
-			},
-			expMetricSeries: []model.MetricSeries{
-				model.MetricSeries{
-					ID:     "test-metric",
-					Labels: map[string]string{"k1": "v1", "k2": "k2", "__name__": "test-metric"},
-					Metrics: []model.Metric{
-						model.Metric{Value: 1.2, TS: now},
-						model.Metric{Value: 3.4, TS: now},
-						model.Metric{Value: 5.5, TS: now},
-					},
-				},
-				model.MetricSeries{
-					ID:     "test-metric",
-					Labels: map[string]string{"k1": "v1", "k2": "k2", "k3": "k3", "__name__": "test-metric"},
-					Metrics: []model.Metric{
-						model.Metric{Value: 6.7, TS: now},
-					},
-				},
-				model.MetricSeries{
-					ID:     "test-metric",
-					Labels: map[string]string{"k5": "v5", "__name__": "test-metric"},
-					Metrics: []model.Metric{
-						model.Metric{Value: 8.9, TS: now},
-					},
-				},
-				model.MetricSeries{
-					ID:     "test-metric2",
-					Labels: map[string]string{"k1": "v1", "k2": "k2", "__name__": "test-metric2"},
-					Metrics: []model.Metric{
-						model.Metric{Value: 10.11, TS: now},
-					},
-				},
-			},
-		},
-		{
-			name: "When Prometheus returns a Vector with multiple metrics with special filter the Gatherer should return the translated metric.",
-			cfg: prometheus.ConfigGatherer{
-				FilterSpecialLabels: true,
-			},
-			prommetric: prommodel.Vector{
-				&prommodel.Sample{
-					Metric:    prommodel.Metric{"k1": "v1", "k2": "k2", "__name__": "test-metric"},
-					Value:     prommodel.SampleValue(1.2),
-					Timestamp: prommodel.TimeFromUnixNano(now.UnixNano()),
-				},
-				&prommodel.Sample{
-					Metric:    prommodel.Metric{"k1": "v1", "k2": "k2", "__name__": "test-metric"},
-					Value:     prommodel.SampleValue(3.4),
-					Timestamp: prommodel.TimeFromUnixNano(now.UnixNano()),
-				},
-				&prommodel.Sample{
-					Metric:    prommodel.Metric{"k1": "v1", "k2": "k2", "__name__": "test-metric"},
-					Value:     prommodel.SampleValue(5.5),
-					Timestamp: prommodel.TimeFromUnixNano(now.UnixNano()),
-				},
-				&prommodel.Sample{
-					Metric:    prommodel.Metric{"k1": "v1", "k2": "k2", "k3": "k3", "__name__": "test-metric"},
-					Value:     prommodel.SampleValue(6.7),
-					Timestamp: prommodel.TimeFromUnixNano(now.UnixNano()),
-				},
-				&prommodel.Sample{
-					Metric:    prommodel.Metric{"k5": "v5", "__name__": "test-metric"},
-					Value:     prommodel.SampleValue(8.9),
-					Timestamp: prommodel.TimeFromUnixNano(now.UnixNano()),
-				},
-				&prommodel.Sample{
-					Metric:    prommodel.Metric{"k1": "v1", "k2": "k2", "__name__": "test-metric2"},
-					Value:     prommodel.SampleValue(10.11),
-					Timestamp: prommodel.TimeFromUnixNano(now.UnixNano()),
-				},
-			},
-			expMetricSeries: []model.MetricSeries{
-				model.MetricSeries{
-					ID:     "test-metric",
-					Labels: map[string]string{"k1": "v1", "k2": "k2"},
-					Metrics: []model.Metric{
-						model.Metric{Value: 1.2, TS: now},
-						model.Metric{Value: 3.4, TS: now},
-						model.Metric{Value: 5.5, TS: now},
-					},
-				},
-				model.MetricSeries{
-					ID:     "test-metric",
-					Labels: map[string]string{"k1": "v1", "k2": "k2", "k3": "k3"},
-					Metrics: []model.Metric{
-						model.Metric{Value: 6.7, TS: now},
-					},
-				},
-				model.MetricSeries{
-					ID:     "test-metric",
-					Labels: map[string]string{"k5": "v5"},
-					Metrics: []model.Metric{
-						model.Metric{Value: 8.9, TS: now},
-					},
-				},
-				model.MetricSeries{
-					ID:     "test-metric2",
-					Labels: map[string]string{"k1": "v1", "k2": "k2"},
-					Metrics: []model.Metric{
-						model.Metric{Value: 10.11, TS: now},
 					},
 				},
 			},
@@ -227,6 +90,156 @@ func TestGathererGatherSingle(t *testing.T) {
 
 			g := prometheus.NewGatherer(test.cfg)
 			gotms, err := g.GatherSingle(context.TODO(), model.Query{}, time.Now())
+
+			if test.expErr {
+				assert.Error(err)
+			} else if assert.NoError(err) {
+				// We don't control the order of the MetricSeries and sorting is harder than checking in
+				// two steps.
+				assert.Len(gotms, len(test.expMetricSeries))
+				for _, gotm := range gotms {
+					assert.Contains(test.expMetricSeries, gotm)
+				}
+			}
+		})
+	}
+}
+
+func TestGathererGatherRange(t *testing.T) {
+	t1 := time.Now().Truncate(time.Second).Add(-1 * time.Minute)
+	t2 := time.Now().Truncate(time.Second).Add(-2 * time.Minute)
+	t3 := time.Now().Truncate(time.Second).Add(-3 * time.Minute)
+	t4 := time.Now().Truncate(time.Second).Add(-4 * time.Minute)
+	t5 := time.Now().Truncate(time.Second).Add(-5 * time.Minute)
+	t6 := time.Now().Truncate(time.Second).Add(-6 * time.Minute)
+	t7 := time.Now().Truncate(time.Second).Add(-7 * time.Minute)
+
+	tests := []struct {
+		name            string
+		prommetric      prommodel.Value
+		cfg             prometheus.ConfigGatherer
+		expMetricSeries []model.MetricSeries
+		expErr          bool
+	}{
+		{
+			name: "When Prometheus returns a matrix metrics the Gatherer should return the translated metric.",
+			prommetric: prommodel.Matrix{
+				&prommodel.SampleStream{
+					Metric: prommodel.Metric{"k1": "v1", "k2": "v2", "__name__": "test-metric"},
+					Values: []prommodel.SamplePair{
+						{
+							Value:     prommodel.SampleValue(1.2),
+							Timestamp: prommodel.TimeFromUnixNano(t1.UnixNano()),
+						},
+						{
+							Value:     prommodel.SampleValue(2.3),
+							Timestamp: prommodel.TimeFromUnixNano(t2.UnixNano()),
+						},
+						{
+							Value:     prommodel.SampleValue(3.4),
+							Timestamp: prommodel.TimeFromUnixNano(t3.UnixNano()),
+						},
+						{
+							Value:     prommodel.SampleValue(4.5),
+							Timestamp: prommodel.TimeFromUnixNano(t4.UnixNano()),
+						},
+						{
+							Value:     prommodel.SampleValue(5.6),
+							Timestamp: prommodel.TimeFromUnixNano(t5.UnixNano()),
+						},
+					},
+				},
+				&prommodel.SampleStream{
+					Metric: prommodel.Metric{"k1": "v1", "k2": "v2", "k3": "v3", "__name__": "test-metric"},
+					Values: []prommodel.SamplePair{
+						{
+							Value:     prommodel.SampleValue(6.7),
+							Timestamp: prommodel.TimeFromUnixNano(t1.UnixNano()),
+						},
+						{
+							Value:     prommodel.SampleValue(7.8),
+							Timestamp: prommodel.TimeFromUnixNano(t2.UnixNano()),
+						},
+						{
+							Value:     prommodel.SampleValue(9.10),
+							Timestamp: prommodel.TimeFromUnixNano(t3.UnixNano()),
+						},
+					},
+				},
+				&prommodel.SampleStream{
+					Metric: prommodel.Metric{"k5": "v5", "__name__": "test-metric"},
+					Values: []prommodel.SamplePair{
+						{
+							Value:     prommodel.SampleValue(10.11),
+							Timestamp: prommodel.TimeFromUnixNano(t6.UnixNano()),
+						},
+					},
+				},
+				&prommodel.SampleStream{
+					Metric: prommodel.Metric{"k1": "v1", "k2": "v2", "__name__": "test-metric2"},
+					Values: []prommodel.SamplePair{
+						{
+							Value:     prommodel.SampleValue(11.12),
+							Timestamp: prommodel.TimeFromUnixNano(t7.UnixNano()),
+						},
+					},
+				},
+			},
+			expMetricSeries: []model.MetricSeries{
+				model.MetricSeries{
+					ID:     `test-metric{k1="v1", k2="v2"}`,
+					Labels: map[string]string{"k1": "v1", "k2": "v2", "__name__": "test-metric"},
+					Metrics: []model.Metric{
+						model.Metric{Value: 1.2, TS: t1},
+						model.Metric{Value: 2.3, TS: t2},
+						model.Metric{Value: 3.4, TS: t3},
+						model.Metric{Value: 4.5, TS: t4},
+						model.Metric{Value: 5.6, TS: t5},
+					},
+				},
+				model.MetricSeries{
+					ID:     `test-metric{k1="v1", k2="v2", k3="v3"}`,
+					Labels: map[string]string{"k1": "v1", "k2": "v2", "k3": "v3", "__name__": "test-metric"},
+					Metrics: []model.Metric{
+						model.Metric{Value: 6.7, TS: t1},
+						model.Metric{Value: 7.8, TS: t2},
+						model.Metric{Value: 9.10, TS: t3},
+					},
+				},
+				model.MetricSeries{
+					ID:     `test-metric{k5="v5"}`,
+					Labels: map[string]string{"k5": "v5", "__name__": "test-metric"},
+					Metrics: []model.Metric{
+						model.Metric{Value: 10.11, TS: t6},
+					},
+				},
+				model.MetricSeries{
+					ID:     `test-metric2{k1="v1", k2="v2"}`,
+					Labels: map[string]string{"k1": "v1", "k2": "v2", "__name__": "test-metric2"},
+					Metrics: []model.Metric{
+						model.Metric{Value: 11.12, TS: t7},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			var expErr error
+			if test.expErr {
+				expErr = errors.New("wanted error")
+			}
+
+			// Mocks.
+			mapi := &mpromv1.API{}
+			mapi.On("QueryRange", mock.Anything, mock.Anything, mock.Anything).Once().Return(test.prommetric, expErr)
+			test.cfg.Client = mapi
+
+			g := prometheus.NewGatherer(test.cfg)
+			gotms, err := g.GatherRange(context.TODO(), model.Query{}, time.Now(), time.Now(), 0)
 
 			if test.expErr {
 				assert.Error(err)


### PR DESCRIPTION
This PR adds range based metric gatherer with the required implementations so we can get multiple metrics so they can be rendered on a graph.

- Add `GatherRange` method to the metrics `Gatherer` interface.
- Add Prometheus `GatherRange implementation.
- Add Fake `GatherRange implementation.
- Add Datasource `GatherRange implementation.
- Refactor how Prometheus Gatherer converts Prometheus `Vector` metric.