### PR TITLE
Don't render missing metrics on graph

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348 // indirect
 	github.com/lucasb-eyer/go-colorful v1.0.1
 	github.com/mattn/go-runewidth v0.0.4 // indirect
-	github.com/mum4k/termdash v0.8.1-0.20190407210819-76c4fc0ec5fd
+	github.com/mum4k/termdash v0.8.1-0.20190419030427-2f1d16bbeab8
 	github.com/nsf/termbox-go v0.0.0-20190325093121-288510b9734e // indirect
 	github.com/oklog/run v1.0.0
 	github.com/prometheus/client_golang v0.9.2

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzp
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mum4k/termdash v0.8.1-0.20190407210819-76c4fc0ec5fd h1:VLu/pYFDkfeOd5kxjOCbMpNkG5YGdxPSs0rjlyOrDFw=
 github.com/mum4k/termdash v0.8.1-0.20190407210819-76c4fc0ec5fd/go.mod h1:l3tO+lJi9LZqXRq7cu7h5/8rDIK3AzelSuq2v/KncxI=
+github.com/mum4k/termdash v0.8.1-0.20190419030427-2f1d16bbeab8 h1:WFVPkaUYvCtXYSOh8hKxiABpea1pGlPEq8XD0BJwvh4=
+github.com/mum4k/termdash v0.8.1-0.20190419030427-2f1d16bbeab8/go.mod h1:l3tO+lJi9LZqXRq7cu7h5/8rDIK3AzelSuq2v/KncxI=
 github.com/nsf/termbox-go v0.0.0-20190325093121-288510b9734e h1:Vbib8wJAaMEF9jusI/kMSYMr/LtRzM7+F9MJgt/nH8k=
 github.com/nsf/termbox-go v0.0.0-20190325093121-288510b9734e/go.mod h1:IuKpRQcYE1Tfu+oAQqaLisqDeXgjyyltCfsaoYN18NQ=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=

--- a/internal/view/render/termdash/graph.go
+++ b/internal/view/render/termdash/graph.go
@@ -2,6 +2,7 @@ package termdash
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/mum4k/termdash/cell"
 	"github.com/mum4k/termdash/container"
@@ -159,10 +160,8 @@ func (g *graph) syncGraph(series render.Series, color cell.Color) error {
 	// Convert to float64 values.
 	values := make([]float64, len(series.Values))
 	for i, value := range series.Values {
-		// Termdash  doesn't support no values.
-		// for now no values will be 0.
-		// TODO(slok): Track the issue https://github.com/mum4k/termdash/issues/184
-		v := 0.0
+		// Use NaN as no value for Termdash.
+		v := math.NaN()
 		if value != nil {
 			v = float64(*value)
 		}


### PR DESCRIPTION
This PR updates termdash and uses NaN floats so we don't render the missing metrics