### PR TITLE
Add null point mode to manage the points in graph that have null values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Add `nullPointMode` series override setting (with `zero` and `connected` strategies).
 - Graphite datasource.
 - Milliseconds unit conversion.
 - Quit grafterm with `Esc` key.

--- a/docs/cfg.md
+++ b/docs/cfg.md
@@ -268,11 +268,13 @@ This widget graphs different metric series in a range. It accepts multiple queri
         "seriesOverride": [
             {
                 "regex": "p99",
-                "color": "#c15c17"
+                "color": "#c15c17",
+                "nullPointMode": "connected"
             },
             {
                 "regex": "p95",
-                "color": "#f2c96d"
+                "color": "#f2c96d",
+                "nullPointMode": "zero"
             },
             {
                 "regex": "p50",
@@ -295,6 +297,9 @@ Each of the graph series can be override based on the legend displayed using a r
 The setting that can be override at this moment are:
 
 - `color`: The color of the displayed series.
+- `nullPointMode`: This will fill the datapoints on the graph that are missing with different strategies, this setting is useful for graphs that don't have sufficent metrics or are very spaced. The strategies are:
+  - `connected`: Will use an already near known value and use this.
+  - `zero`: Will fill the data point value with 0s.
 
 ##### `visualization.yAxis`
 

--- a/internal/model/dashboard_test.go
+++ b/internal/model/dashboard_test.go
@@ -393,6 +393,19 @@ func TestValidateDashboard(t *testing.T) {
 			},
 			expErr: true,
 		},
+		{
+			name: "A graph widget series override should have a valid null point mode.",
+			dashboard: func() model.Dashboard {
+				d := getBaseDashboard()
+				w := d.Widgets[2]
+				w.Graph.Visualization.SeriesOverride = []model.SeriesOverride{
+					model.SeriesOverride{Regex: "2..", Color: "#FFF000", NullPointMode: "wrong"},
+				}
+				d.Widgets[2] = w
+				return d
+			},
+			expErr: true,
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/service/configuration/v1/v1_test.go
+++ b/internal/service/configuration/v1/v1_test.go
@@ -90,15 +90,18 @@ var (
 			"seriesOverride": [
               {
                 "regex": "p99",
-                "color": "#c15c17"
+								"color": "#c15c17",
+								"nullPointMode": "connected"
               },
               {
                 "regex": "p95",
-                "color": "#f2c96d"
+								"color": "#f2c96d",
+								"nullPointMode": "null"
               },
               {
                 "regex": "p50",
-                "color": "#f9ba8f"
+								"color": "#f9ba8f",
+								"nullPointMode": "zero"
               }
 			],
 			"yAxis": {
@@ -194,9 +197,9 @@ var (
 							RightSide: true,
 						},
 						SeriesOverride: []model.SeriesOverride{
-							{Regex: "p99", Color: "#c15c17", CompiledRegex: regexp.MustCompile("p99")},
-							{Regex: "p95", Color: "#f2c96d", CompiledRegex: regexp.MustCompile("p95")},
-							{Regex: "p50", Color: "#f9ba8f", CompiledRegex: regexp.MustCompile("p50")},
+							{Regex: "p99", Color: "#c15c17", CompiledRegex: regexp.MustCompile("p99"), NullPointMode: model.NullPointModeConnected},
+							{Regex: "p95", Color: "#f2c96d", CompiledRegex: regexp.MustCompile("p95"), NullPointMode: model.NullPointModeAsNull},
+							{Regex: "p50", Color: "#f9ba8f", CompiledRegex: regexp.MustCompile("p50"), NullPointMode: model.NullPointModeAsZero},
 						},
 						YAxis: model.YAxis{
 							ValueRepresentation: model.ValueRepresentation{

--- a/internal/view/misc.go
+++ b/internal/view/misc.go
@@ -106,18 +106,13 @@ type widgetColorManager struct {
 // GetColorFromSeriesLegend will return the configured color for the matching regex with the series
 // legend, if there is no match then it will return a default color.
 func (w *widgetColorManager) GetColorFromSeriesLegend(cfg model.GraphWidgetSource, legend string) string {
-	// Check if it matches the regex of any of the visualization
-	// override series for a custom color.
-	for _, so := range cfg.Visualization.SeriesOverride {
-		if so.CompiledRegex != nil && so.CompiledRegex.MatchString(legend) && so.Color != "" {
-			return so.Color
-		}
+	so, ok := seriesOverride(cfg.Visualization.SeriesOverride, legend)
+	if ok && so.Color != "" {
+		return so.Color
 	}
 
 	// No match, get the next default color,
-	color := w.GetDefaultColor()
-
-	return color
+	return w.GetDefaultColor()
 }
 
 // GetColorFromThresholds gets the correct color based on a ordered list of thresholds and a value.
@@ -148,4 +143,17 @@ func (w *widgetColorManager) GetDefaultColor() string {
 	}
 
 	return color
+}
+
+// seriesOverride returns the series override based on the series legend
+// if it finds one, if not then it will return false in the ok return
+// argument.
+func seriesOverride(seriesOverride []model.SeriesOverride, legend string) (so model.SeriesOverride, ok bool) {
+	for _, so := range seriesOverride {
+		if so.CompiledRegex != nil && so.CompiledRegex.MatchString(legend) {
+			return so, true
+		}
+	}
+
+	return model.SeriesOverride{}, false
 }


### PR DESCRIPTION
This adds a policy to the graph series override that will act when there are no datapoints for a specific time range, this is handy on graphs that there is spaced data for the time range.

An example could be a datapoint every 1m and we have a graph of 30m, 30 datapoints in a graph that could render 400 points in the terminal would not be rendered.

This happens mostly with Graphite datasource API calls, because Prometheus already calculates the step used on the query API call (that grafterm calculates already) to return the correct number of datapoints so we don't need to do this.