### PR TITLE
Readme.md: add VictoriaMetrics to datasource examples

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -132,6 +132,9 @@ Grafterm dashboards can have default datasources but the user can override these
     "m3db": {
       "prometheus": { "address": "http://127.0.0.1:9093" }
     },
+    "victoriametrics": {
+      "prometheus": { "address": "http://127.0.0.1:8428" }
+    },
     "wikimedia": {
       "graphite": { "address": "https://graphite.wikimedia.org" }
     }


### PR DESCRIPTION
VictoriaMetrics supports Prometheus querying API and it listens for 8428 port by default. See https://github.com/VictoriaMetrics/VictoriaMetrics/blob/master/README.md#grafana-setup for details.